### PR TITLE
Convert native JUnit assertions to AssertJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,11 @@ dependencies {
     compile 'com.google.guava:guava:30.0-jre'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.18.1'
     testCompile "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
     testCompile "org.junit.jupiter:junit-jupiter-params:${junitJupiterVersion}"
-    testCompile 'org.mockito:mockito-core:3.6.28'
+    testCompile group: 'org.kiwiproject', name: 'kiwi-test', version: '0.12.0'
+    testCompile 'org.mockito:mockito-core:3.7.0'
 
     // To avoid compiler warning about use of experimental features in JUnit 5
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.0'

--- a/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
+++ b/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
@@ -18,7 +18,9 @@
 
 package com.github.rholder.retry;
 
-import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
@@ -34,18 +36,17 @@ class AttemptTimeLimiterTest {
             .build();
 
     @Test
-    void testAttemptTimeLimit() throws Exception {
-        try {
-            r.call(new SleepyOut(0L));
-        } catch (Exception e) {
-            Assertions.fail("Should not timeout");
-        }
+    void testAttemptTimeLimitWhenShouldNotTimeOut() {
+        assertThatCode(() -> r.call(new SleepyOut(0L)))
+                .describedAs("Should not timeout")
+                .doesNotThrowAnyException();
+    }
 
-        try {
-            r.call(new SleepyOut(10 * 1000L));
-            Assertions.fail("Expected timeout exception");
-        } catch (RetryException ignored) {
-        }
+    @Test
+    void testAttemptTimeLimitWhenShouldTimeOut() {
+        assertThatThrownBy(() -> r.call(new SleepyOut(10 * 1000L)))
+                .describedAs("Expected timeout exception")
+                .isExactlyInstanceOf(RetryException.class);
     }
 
     static class SleepyOut implements Callable<Void> {

--- a/src/test/java/com/github/rholder/retry/AttemptTimeLimitersTest.java
+++ b/src/test/java/com/github/rholder/retry/AttemptTimeLimitersTest.java
@@ -1,5 +1,5 @@
 /*
- * copyright 2017-2018 Robert Huffman
+ * Copyright 2017-2018 Robert Huffman
  * Modifications copyright 2020-2021 Kiwi Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  */
 package com.github.rholder.retry;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
@@ -42,8 +42,10 @@ class AttemptTimeLimitersTest {
                     AttemptTimeLimiters.fixedTimeLimit(1, TimeUnit.SECONDS);
             timeLimiter.call(callable);
         }
-        assertTrue(threadsUsed.size() < iterations,
-                () -> "Should have used less than " + iterations + " threads");
+
+        assertThat(threadsUsed.size())
+                .describedAs("Should have used less than %d threads", iterations)
+                .isLessThan(iterations);
     }
 
 }

--- a/src/test/java/com/github/rholder/retry/RetryerTest.java
+++ b/src/test/java/com/github/rholder/retry/RetryerTest.java
@@ -1,5 +1,5 @@
 /*
- * copyright 2017-2018 Robert Huffman
+ * Copyright 2017-2018 Robert Huffman
  * Modifications copyright 2020-2021 Kiwi Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,8 @@
 
 package com.github.rholder.retry;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,317 +32,312 @@ import java.util.stream.Stream;
 
 class RetryerTest {
 
-  @ParameterizedTest
-  @MethodSource("checkedAndUnchecked")
-  void testCallThrowsWithNoRetryOnException(Class<? extends Throwable> throwable) throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder().build();
-    Thrower thrower = new Thrower(throwable, 5);
-    try {
-      retryer.call(thrower);
-      fail("Should have thrown");
-    } catch (RetryException e) {
-      assertSame(e.getCause().getClass(), throwable);
-    }
-    assertEquals(1, thrower.invocations);
-  }
-
-  @ParameterizedTest
-  @MethodSource("unchecked")
-  void testRunThrowsWithNoRetryOnException(Class<? extends Throwable> throwable) throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder().build();
-    Thrower thrower = new Thrower(throwable, 5);
-    try {
-      retryer.run(thrower);
-      fail("Should have thrown");
-    } catch (RetryException e) {
-      assertSame(e.getCause().getClass(), throwable);
-    }
-    assertEquals(1, thrower.invocations);
-  }
-
-  @ParameterizedTest
-  @MethodSource("checkedAndUnchecked")
-  void testCallThrowsWithRetryOnException(Class<? extends Throwable> throwable) throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder()
-        .retryIfExceptionOfType(Throwable.class)
-        .build();
-    Thrower thrower = new Thrower(throwable, 5);
-    retryer.call(thrower);
-    assertEquals(5, thrower.invocations);
-  }
-
-  @ParameterizedTest
-  @MethodSource("unchecked")
-  void testRunThrowsWithRetryOnException(Class<? extends Throwable> throwable) throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder()
-        .retryIfExceptionOfType(Throwable.class)
-        .build();
-    Thrower thrower = new Thrower(throwable, 5);
-    retryer.run(thrower);
-    assertEquals(5, thrower.invocations);
-  }
-
-  @ParameterizedTest
-  @MethodSource("checkedAndUnchecked")
-  void testCallThrowsSubclassWithRetryOnException(Class<? extends Throwable> throwable) throws Exception {
-    @SuppressWarnings("unchecked")
-    Class<? extends Throwable> superclass = (Class<? extends Throwable>) throwable.getSuperclass();
-    Retryer retryer = RetryerBuilder.newBuilder()
-        .retryIfExceptionOfType(superclass)
-        .build();
-    Thrower thrower = new Thrower(throwable, 5);
-    retryer.call(thrower);
-    assertEquals(5, thrower.invocations);
-  }
-
-  @ParameterizedTest
-  @MethodSource("unchecked")
-  void testRunThrowsSubclassWithRetryOnException(Class<? extends Throwable> throwable) throws Exception {
-    @SuppressWarnings("unchecked")
-    Class<? extends Throwable> superclass = (Class<? extends Throwable>) throwable.getSuperclass();
-    Retryer retryer = RetryerBuilder.newBuilder()
-        .retryIfExceptionOfType(superclass)
-        .build();
-    Thrower thrower = new Thrower(throwable, 5);
-    retryer.run(thrower);
-    assertEquals(5, thrower.invocations);
-  }
-
-  @ParameterizedTest
-  @MethodSource("checkedAndUnchecked")
-  void testCallThrowsWhenRetriesAreStopped(Class<? extends Throwable> throwable) throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder()
-        .retryIfExceptionOfType(throwable)
-        .withStopStrategy(StopStrategies.stopAfterAttempt(3))
-        .build();
-    Thrower thrower = new Thrower(throwable, 5);
-    try {
-      retryer.call(thrower);
-      fail("Should have thrown");
-    } catch (RetryException e) {
-      assertSame(e.getCause().getClass(), throwable);
-    }
-    assertEquals(3, thrower.invocations);
-  }
-
-  @ParameterizedTest
-  @MethodSource("unchecked")
-  void testRunThrowsWhenRetriesAreStopped(Class<? extends Throwable> throwable) throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder()
-        .retryIfExceptionOfType(throwable)
-        .withStopStrategy(StopStrategies.stopAfterAttempt(3))
-        .build();
-    Thrower thrower = new Thrower(throwable, 5);
-    try {
-      retryer.run(thrower);
-      fail("Should have thrown");
-    } catch (RetryException e) {
-      assertSame(e.getCause().getClass(), throwable);
-    }
-    assertEquals(3, thrower.invocations);
-  }
-
-  @Test
-  void testCallThatIsInterrupted() {
-    Retryer retryer = RetryerBuilder.newBuilder()
-            .retryIfRuntimeException()
-            .withStopStrategy(StopStrategies.stopAfterAttempt(10))
-            .build();
-    Interrupter thrower = new Interrupter(4);
-    boolean interrupted = false;
-    try {
-      retryer.call(thrower);
-      fail("Should have thrown");
-    } catch (InterruptedException ignored) {
-      interrupted = true;
-    } catch (Exception e) {
-      // TODO Clean this up or remove
-      System.out.println(e);
+    @ParameterizedTest
+    @MethodSource("checkedAndUnchecked")
+    void testCallThrowsWithNoRetryOnException(Class<? extends Throwable> throwableClass) throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder().build();
+        Thrower thrower = new Thrower(throwableClass, 5);
+        try {
+            retryer.call(thrower);
+            fail("Should have thrown");
+        } catch (RetryException e) {
+            assertThat(e.getCause().getClass()).isSameAs(throwableClass);
+        }
+        assertThat(thrower.invocations).isOne();
     }
 
-    assertTrue(interrupted);
-    assertEquals(4, thrower.invocations);
-  }
-
-  @Test
-  void testRunThatIsInterrupted() throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder()
-            .retryIfRuntimeException()
-            .withStopStrategy(StopStrategies.stopAfterAttempt(10))
-            .build();
-    Interrupter thrower = new Interrupter(4);
-    boolean interrupted = false;
-    try {
-      retryer.run(thrower);
-      fail("Should have thrown");
-    } catch(InterruptedException ignored) {
-      interrupted = true;
+    @ParameterizedTest
+    @MethodSource("unchecked")
+    void testRunThrowsWithNoRetryOnException(Class<? extends Throwable> throwableClass) throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder().build();
+        Thrower thrower = new Thrower(throwableClass, 5);
+        try {
+            retryer.run(thrower);
+            fail("Should have thrown");
+        } catch (RetryException e) {
+            assertThat(e.getCause().getClass()).isSameAs(throwableClass);
+        }
+        assertThat(thrower.invocations).isOne();
     }
 
-    //noinspection ConstantConditions
-    assertTrue(interrupted);
-    assertEquals(4, thrower.invocations);
-  }
-
-  @Test
-  void testCallWhenBlockerIsInterrupted() throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder()
-            .retryIfException()
-            .withStopStrategy(StopStrategies.stopAfterAttempt(10))
-            .withBlockStrategy(new InterruptingBlockStrategy(3))
-            .build();
-    Thrower thrower = new Thrower(Exception.class, 5);
-    boolean interrupted = false;
-    try {
-      retryer.call(thrower);
-      fail("Should have thrown");
-    } catch (InterruptedException e) {
-      interrupted = true;
-    }
-    //noinspection ConstantConditions
-    assertTrue(interrupted);
-    assertEquals(3, thrower.invocations);
-  }
-
-  @Test
-  void testRunWhenBlockerIsInterrupted() throws Exception {
-    Retryer retryer = RetryerBuilder.newBuilder()
-            .retryIfException()
-            .withStopStrategy(StopStrategies.stopAfterAttempt(10))
-            .withBlockStrategy(new InterruptingBlockStrategy(3))
-            .build();
-    Thrower thrower = new Thrower(Exception.class, 5);
-    boolean interrupted = false;
-    try {
-      retryer.run(thrower);
-      fail("Should have thrown");
-    } catch (InterruptedException e) {
-      interrupted = true;
-    }
-    //noinspection ConstantConditions
-    assertTrue(interrupted);
-    assertEquals(3, thrower.invocations);
-  }
-
-  private static Stream<Arguments> checkedAndUnchecked() {
-    return Stream.concat(unchecked(), Stream.of(
-        Arguments.of(Exception.class),
-        Arguments.of(IOException.class)
-    ));
-  }
-
-  private static Stream<Arguments> unchecked() {
-    return Stream.of(
-        Arguments.of(Error.class),
-        Arguments.of(RuntimeException.class),
-        Arguments.of(NullPointerException.class)
-    );
-  }
-
-  /**
-   * BlockStrategy that interrupts the thread
-   */
-  private static class InterruptingBlockStrategy implements BlockStrategy {
-
-    private final int invocationToInterrupt;
-
-    private int currentInvocation;
-
-    InterruptingBlockStrategy(int invocationToInterrupt) {
-      this.invocationToInterrupt = invocationToInterrupt;
+    @ParameterizedTest
+    @MethodSource("checkedAndUnchecked")
+    void testCallThrowsWithRetryOnException(Class<? extends Throwable> throwable) throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfExceptionOfType(Throwable.class)
+                .build();
+        Thrower thrower = new Thrower(throwable, 5);
+        retryer.call(thrower);
+        assertThat(thrower.invocations).isEqualTo(5);
     }
 
-    @Override
-    public void block(long sleepTime) throws InterruptedException {
-      ++currentInvocation;
-      if (currentInvocation == invocationToInterrupt) {
-        throw new InterruptedException("Block strategy interrupted itself");
-      } else {
-        Thread.sleep(sleepTime);
-      }
-    }
-  }
-
-  /**
-   * Callable that throws an exception on a specified attempt (indexed starting with 1).
-   * Calls before the interrupt attempt throw an Exception.
-   */
-  private static class Interrupter implements Callable<Void>, Runnable {
-
-    private final int interruptAttempt;
-
-    private int invocations;
-
-    Interrupter(int interruptAttempt) {
-      this.interruptAttempt = interruptAttempt;
+    @ParameterizedTest
+    @MethodSource("unchecked")
+    void testRunThrowsWithRetryOnException(Class<? extends Throwable> throwableClass) throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfExceptionOfType(Throwable.class)
+                .build();
+        Thrower thrower = new Thrower(throwableClass, 5);
+        retryer.run(thrower);
+        assertThat(thrower.invocations).isEqualTo(5);
     }
 
-    @Override
-    public Void call() throws InterruptedException {
-      invocations++;
-      if (invocations == interruptAttempt) {
-        throw new InterruptedException("Interrupted invocation " + invocations);
-      } else {
-        throw new RuntimeException("Throwing on invocaion " + invocations);
-      }
+    @ParameterizedTest
+    @MethodSource("checkedAndUnchecked")
+    void testCallThrowsSubclassWithRetryOnException(Class<? extends Throwable> throwableClass) throws Exception {
+        @SuppressWarnings("unchecked")
+        Class<? extends Throwable> superclass = (Class<? extends Throwable>) throwableClass.getSuperclass();
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfExceptionOfType(superclass)
+                .build();
+        Thrower thrower = new Thrower(throwableClass, 5);
+        retryer.call(thrower);
+        assertThat(thrower.invocations).isEqualTo(5);
     }
 
-    @Override
-    public void run() throws RuntimeException {
-      try {
-        call();
-      } catch(InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
-      }
+    @ParameterizedTest
+    @MethodSource("unchecked")
+    void testRunThrowsSubclassWithRetryOnException(Class<? extends Throwable> throwableClass) throws Exception {
+        @SuppressWarnings("unchecked")
+        Class<? extends Throwable> superclass = (Class<? extends Throwable>) throwableClass.getSuperclass();
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfExceptionOfType(superclass)
+                .build();
+        Thrower thrower = new Thrower(throwableClass, 5);
+        retryer.run(thrower);
+        assertThat(thrower.invocations).isEqualTo(5);
     }
 
-  }
-
-  private static class Thrower implements Callable<Void>, Runnable {
-
-    private final Class<? extends Throwable> throwableType;
-
-    private final int successAttempt;
-
-    private int invocations = 0;
-
-    Thrower(Class<? extends Throwable> throwableType, int successAttempt) {
-      this.throwableType = throwableType;
-      this.successAttempt = successAttempt;
+    @ParameterizedTest
+    @MethodSource("checkedAndUnchecked")
+    void testCallThrowsWhenRetriesAreStopped(Class<? extends Throwable> throwableClass) throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfExceptionOfType(throwableClass)
+                .withStopStrategy(StopStrategies.stopAfterAttempt(3))
+                .build();
+        Thrower thrower = new Thrower(throwableClass, 5);
+        try {
+            retryer.call(thrower);
+            fail("Should have thrown");
+        } catch (RetryException e) {
+            assertThat(e.getCause().getClass()).isSameAs(throwableClass);
+        }
+        assertThat(thrower.invocations).isEqualTo(3);
     }
 
-    @Override
-    public Void call() throws Exception {
-      invocations++;
-      if (invocations == successAttempt) {
-        return null;
-      }
-      if (Error.class.isAssignableFrom(throwableType)) {
-        throw (Error) throwable();
-      }
-      throw (Exception) throwable();
+    @ParameterizedTest
+    @MethodSource("unchecked")
+    void testRunThrowsWhenRetriesAreStopped(Class<? extends Throwable> throwableClass) throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfExceptionOfType(throwableClass)
+                .withStopStrategy(StopStrategies.stopAfterAttempt(3))
+                .build();
+        Thrower thrower = new Thrower(throwableClass, 5);
+        try {
+            retryer.run(thrower);
+            fail("Should have thrown");
+        } catch (RetryException e) {
+            assertThat(e.getCause().getClass()).isSameAs(throwableClass);
+        }
+        assertThat(thrower.invocations).isEqualTo(3);
     }
 
-    @Override
-    public void run() {
-      invocations++;
-      if (invocations == successAttempt) {
-        return;
-      }
-      if (Error.class.isAssignableFrom(throwableType)) {
-        throw (Error) throwable();
-      }
-      throw (RuntimeException) throwable();
+    @Test
+    void testCallThatIsInterrupted() {
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfRuntimeException()
+                .withStopStrategy(StopStrategies.stopAfterAttempt(10))
+                .build();
+        Interrupter thrower = new Interrupter(4);
+        boolean interrupted = false;
+        try {
+            retryer.call(thrower);
+            fail("Should have thrown");
+        } catch (InterruptedException ignored) {
+            interrupted = true;
+        } catch (Exception e) {
+            // TODO Clean this up or remove
+            System.out.println(e);
+        }
+        assertThat(interrupted).isTrue();
+        assertThat(thrower.invocations).isEqualTo(4);
     }
 
-    private Throwable throwable() {
-      try {
-        return throwableType.getDeclaredConstructor().newInstance();
-      } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-        throw new RuntimeException("Failed to create throwable of type " + throwableType);
-      }
+    @Test
+    void testRunThatIsInterrupted() throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfRuntimeException()
+                .withStopStrategy(StopStrategies.stopAfterAttempt(10))
+                .build();
+        Interrupter thrower = new Interrupter(4);
+        boolean interrupted = false;
+        try {
+            retryer.run(thrower);
+            fail("Should have thrown");
+        } catch (InterruptedException ignored) {
+            interrupted = true;
+        }
+        assertThat(interrupted).isTrue();
+        assertThat(thrower.invocations).isEqualTo(4);
     }
-  }
+
+    @Test
+    void testCallWhenBlockerIsInterrupted() throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfException()
+                .withStopStrategy(StopStrategies.stopAfterAttempt(10))
+                .withBlockStrategy(new InterruptingBlockStrategy(3))
+                .build();
+        Thrower thrower = new Thrower(Exception.class, 5);
+        boolean interrupted = false;
+        try {
+            retryer.call(thrower);
+            fail("Should have thrown");
+        } catch (InterruptedException e) {
+            interrupted = true;
+        }
+        assertThat(interrupted).isTrue();
+        assertThat(thrower.invocations).isEqualTo(3);
+    }
+
+    @Test
+    void testRunWhenBlockerIsInterrupted() throws Exception {
+        Retryer retryer = RetryerBuilder.newBuilder()
+                .retryIfException()
+                .withStopStrategy(StopStrategies.stopAfterAttempt(10))
+                .withBlockStrategy(new InterruptingBlockStrategy(3))
+                .build();
+        Thrower thrower = new Thrower(Exception.class, 5);
+        boolean interrupted = false;
+        try {
+            retryer.run(thrower);
+            fail("Should have thrown");
+        } catch (InterruptedException e) {
+            interrupted = true;
+        }
+        assertThat(interrupted).isTrue();
+        assertThat(thrower.invocations).isEqualTo(3);
+    }
+
+    private static Stream<Arguments> checkedAndUnchecked() {
+        return Stream.concat(unchecked(), Stream.of(
+                Arguments.of(Exception.class),
+                Arguments.of(IOException.class)
+        ));
+    }
+
+    private static Stream<Arguments> unchecked() {
+        return Stream.of(
+                Arguments.of(Error.class),
+                Arguments.of(RuntimeException.class),
+                Arguments.of(NullPointerException.class)
+        );
+    }
+
+    /**
+     * BlockStrategy that interrupts the thread
+     */
+    private static class InterruptingBlockStrategy implements BlockStrategy {
+
+        private final int invocationToInterrupt;
+
+        private int currentInvocation;
+
+        InterruptingBlockStrategy(int invocationToInterrupt) {
+            this.invocationToInterrupt = invocationToInterrupt;
+        }
+
+        @Override
+        public void block(long sleepTime) throws InterruptedException {
+            ++currentInvocation;
+            if (currentInvocation == invocationToInterrupt) {
+                throw new InterruptedException("Block strategy interrupted itself");
+            } else {
+                Thread.sleep(sleepTime);
+            }
+        }
+    }
+
+    /**
+     * Callable that throws an exception on a specified attempt (indexed starting with 1).
+     * Calls before the interrupt attempt throw an Exception.
+     */
+    private static class Interrupter implements Callable<Void>, Runnable {
+
+        private final int interruptAttempt;
+
+        private int invocations;
+
+        Interrupter(int interruptAttempt) {
+            this.interruptAttempt = interruptAttempt;
+        }
+
+        @Override
+        public Void call() throws InterruptedException {
+            invocations++;
+            if (invocations == interruptAttempt) {
+                throw new InterruptedException("Interrupted invocation " + invocations);
+            } else {
+                throw new RuntimeException("Throwing on invocaion " + invocations);
+            }
+        }
+
+        @Override
+        public void run() throws RuntimeException {
+            try {
+                call();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    private static class Thrower implements Callable<Void>, Runnable {
+
+        private final Class<? extends Throwable> throwableType;
+
+        private final int successAttempt;
+
+        private int invocations = 0;
+
+        Thrower(Class<? extends Throwable> throwableType, int successAttempt) {
+            this.throwableType = throwableType;
+            this.successAttempt = successAttempt;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            invocations++;
+            if (invocations == successAttempt) {
+                return null;
+            }
+            if (Error.class.isAssignableFrom(throwableType)) {
+                throw (Error) throwable();
+            }
+            throw (Exception) throwable();
+        }
+
+        @Override
+        public void run() {
+            invocations++;
+            if (invocations == successAttempt) {
+                return;
+            }
+            if (Error.class.isAssignableFrom(throwableType)) {
+                throw (Error) throwable();
+            }
+            throw (RuntimeException) throwable();
+        }
+
+        private Throwable throwable() {
+            try {
+                return throwableType.getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+                throw new RuntimeException("Failed to create throwable of type " + throwableType);
+            }
+        }
+    }
 }
 

--- a/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
+++ b/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
@@ -18,42 +18,59 @@
 
 package com.github.rholder.retry;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.TimeUnit;
 
 class StopStrategiesTest {
 
-    @Test
-    void testNeverStop() {
-        Assertions.assertFalse(StopStrategies.neverStop().shouldStop(failedAttempt(3, 6546L)));
+    @ParameterizedTest
+    @ValueSource(ints = {2, 3, 42, 65_535, Integer.MAX_VALUE})
+    void testNeverStop(int attemptNumber) {
+        var stopStrategy = StopStrategies.neverStop();
+        assertThat(stopStrategy.shouldStop(failedAttempt(attemptNumber, 6546L)))
+                .isFalse();
     }
 
-    @Test
-    void testStopAfterAttempt() {
-        Assertions.assertFalse(StopStrategies.stopAfterAttempt(3).shouldStop(failedAttempt(2, 6546L)));
-        Assertions.assertTrue(StopStrategies.stopAfterAttempt(3).shouldStop(failedAttempt(3, 6546L)));
-        Assertions.assertTrue(StopStrategies.stopAfterAttempt(3).shouldStop(failedAttempt(4, 6546L)));
+    @ParameterizedTest
+    @CsvSource({
+            "2, false",
+            "3, true",
+            "4, true"
+    })
+    void testStopAfterAttempt(int attemptNumber, boolean expectedShouldStop) {
+        var stopStrategy = StopStrategies.stopAfterAttempt(3);
+        assertThat(stopStrategy.shouldStop(failedAttempt(attemptNumber, 6546L)))
+                .isEqualTo(expectedShouldStop);
     }
 
-    @Test
-    void testStopAfterDelayWithMilliseconds() {
-        Assertions.assertFalse(StopStrategies.stopAfterDelay(1000, MILLISECONDS)
-                .shouldStop(failedAttempt(2, 999L)));
-        Assertions.assertTrue(StopStrategies.stopAfterDelay(1000, MILLISECONDS)
-                .shouldStop(failedAttempt(2, 1000L)));
-        Assertions.assertTrue(StopStrategies.stopAfterDelay(1000, MILLISECONDS)
-                .shouldStop(failedAttempt(2, 1001L)));
+    @ParameterizedTest
+    @CsvSource({
+            "999, false",
+            "1000, true",
+            "1001, true"
+    })
+    void testStopAfterDelayWithMilliseconds(long delaySinceFirstAttempt, boolean expectedShouldStop) {
+        //noinspection deprecation
+        var stopStrategy = StopStrategies.stopAfterDelay(1000);
+        assertThat(stopStrategy.shouldStop(failedAttempt(2, delaySinceFirstAttempt)))
+                .isEqualTo(expectedShouldStop);
     }
 
-    @Test
-    void testStopAfterDelayWithTimeUnit() {
-        Assertions.assertFalse(StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS).shouldStop(failedAttempt(2, 999L)));
-        Assertions.assertTrue(StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS).shouldStop(failedAttempt(2, 1000L)));
-        Assertions.assertTrue(StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS).shouldStop(failedAttempt(2, 1001L)));
+    @ParameterizedTest
+    @CsvSource({
+            "999, false",
+            "1000, true",
+            "1001, true"
+    })
+    void testStopAfterDelayWithTimeUnit(long delaySinceFirstAttempt, boolean expectedShouldStop) {
+        var stopStrategy = StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS);
+        assertThat(stopStrategy.shouldStop(failedAttempt(2, delaySinceFirstAttempt)))
+                .isEqualTo(expectedShouldStop);
     }
 
     private Attempt<Boolean> failedAttempt(int attemptNumber, long delaySinceFirstAttempt) {

--- a/src/test/java/com/github/rholder/retry/WaitStrategiesTest.java
+++ b/src/test/java/com/github/rholder/retry/WaitStrategiesTest.java
@@ -18,13 +18,14 @@
 
 package com.github.rholder.retry;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -32,144 +33,162 @@ class WaitStrategiesTest {
 
     @Test
     void testNoWait() {
-        WaitStrategy noWait = WaitStrategies.noWait();
-        assertEquals(0L, noWait.computeSleepTime(failedAttempt(18, 9879L)));
+        var noWait = WaitStrategies.noWait();
+        assertThat(noWait.computeSleepTime(failedAttempt(18, 9879L)))
+                .isZero();
     }
 
     @Test
     void testFixedWait() {
-        WaitStrategy fixedWait = WaitStrategies.fixedWait(1000L, TimeUnit.MILLISECONDS);
-        assertEquals(1000L, fixedWait.computeSleepTime(failedAttempt(12, 6546L)));
+        var fixedWait = WaitStrategies.fixedWait(1000L, TimeUnit.MILLISECONDS);
+        assertThat(fixedWait.computeSleepTime(failedAttempt(12, 6546L)))
+                .isEqualTo(1000L);
     }
 
-    @Test
-    void testIncrementingWait() {
-        WaitStrategy incrementingWait = WaitStrategies.incrementingWait(500L, TimeUnit.MILLISECONDS, 100L, TimeUnit.MILLISECONDS);
-        assertEquals(500L, incrementingWait.computeSleepTime(failedAttempt(1, 6546L)));
-        assertEquals(600L, incrementingWait.computeSleepTime(failedAttempt(2, 6546L)));
-        assertEquals(700L, incrementingWait.computeSleepTime(failedAttempt(3, 6546L)));
+    @ParameterizedTest
+    @CsvSource({
+            "1, 500",
+            "2, 600",
+            "3, 700",
+    })
+    void testIncrementingWait(int attemptNumber, long expectedSleepTime) {
+        var incrementingWait = WaitStrategies.incrementingWait(500L, TimeUnit.MILLISECONDS, 100L, TimeUnit.MILLISECONDS);
+        assertThat(incrementingWait.computeSleepTime(failedAttempt(attemptNumber, 6546L)))
+                .isEqualTo(expectedSleepTime);
     }
 
     @Test
     void testRandomWait() {
-        WaitStrategy randomWait = WaitStrategies.randomWait(1000L, TimeUnit.MILLISECONDS, 2000L, TimeUnit.MILLISECONDS);
-        Set<Long> times = Sets.newHashSet();
+        var randomWait = WaitStrategies.randomWait(1000L, TimeUnit.MILLISECONDS, 2000L, TimeUnit.MILLISECONDS);
+        var times = new HashSet<Long>();
         times.add(randomWait.computeSleepTime(failedAttempt(1, 6546L)));
         times.add(randomWait.computeSleepTime(failedAttempt(1, 6546L)));
         times.add(randomWait.computeSleepTime(failedAttempt(1, 6546L)));
         times.add(randomWait.computeSleepTime(failedAttempt(1, 6546L)));
-        assertTrue(times.size() > 1); // if not, the random is not random
-        for (long time : times) {
-            assertTrue(time >= 1000L);
-            assertTrue(time <= 2000L);
-        }
+
+        assertThat(times).hasSizeGreaterThan(1);
+        times.forEach(time -> assertThat(time).isBetween(1000L, 2000L));
     }
 
     @Test
     void testRandomWaitWithoutMinimum() {
-        WaitStrategy randomWait = WaitStrategies.randomWait(2000L, TimeUnit.MILLISECONDS);
-        Set<Long> times = Sets.newHashSet();
+        var randomWait = WaitStrategies.randomWait(2000L, TimeUnit.MILLISECONDS);
+        var times = new HashSet<Long>();
         times.add(randomWait.computeSleepTime(failedAttempt(1, 6546L)));
         times.add(randomWait.computeSleepTime(failedAttempt(1, 6546L)));
         times.add(randomWait.computeSleepTime(failedAttempt(1, 6546L)));
         times.add(randomWait.computeSleepTime(failedAttempt(1, 6546L)));
-        assertTrue(times.size() > 1); // if not, the random is not random
-        for (long time : times) {
-            assertTrue(time >= 0L);
-            assertTrue(time <= 2000L);
-        }
+
+        assertThat(times).hasSizeGreaterThan(1);
+        times.forEach(time -> assertThat(time).isBetween(0L, 2000L));
     }
 
-    @Test
-    void testExponential() {
-        WaitStrategy exponentialWait = WaitStrategies.exponentialWait();
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(1, 0)) == 2);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(2, 0)) == 4);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(3, 0)) == 8);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(4, 0)) == 16);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(5, 0)) == 32);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(6, 0)) == 64);
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4, 5, 6})
+    void testExponential(int attemptNumber) {
+        var exponentialWait = WaitStrategies.exponentialWait();
+        assertThat(exponentialWait.computeSleepTime(failedAttempt(attemptNumber, 0)))
+                .isEqualTo((long) Math.pow(2, attemptNumber));
     }
 
-    @Test
-    void testExponentialWithMaximumWait() {
-        WaitStrategy exponentialWait = WaitStrategies.exponentialWait(40, TimeUnit.MILLISECONDS);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(1, 0)) == 2);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(2, 0)) == 4);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(3, 0)) == 8);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(4, 0)) == 16);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(5, 0)) == 32);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(6, 0)) == 40);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(7, 0)) == 40);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(8, 0)) == 40);
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8})
+    void testExponentialWithMaximumWait(int attemptNumber) {
+        var maximumTime = 40;
+        var exponentialWait = WaitStrategies.exponentialWait(maximumTime, TimeUnit.MILLISECONDS);
+
+        var unadjustedWait = (long) Math.pow(2, attemptNumber);
+        var expectedWait = Math.min(unadjustedWait, maximumTime);
+
+        assertThat(exponentialWait.computeSleepTime(failedAttempt(attemptNumber, 0)))
+                .isEqualTo(expectedWait);
     }
 
-    @Test
-    void testExponentialWithMultiplierAndMaximumWait() {
-        WaitStrategy exponentialWait = WaitStrategies.exponentialWait(1000, 50000, TimeUnit.MILLISECONDS);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(1, 0)) == 2000);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(2, 0)) == 4000);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(3, 0)) == 8000);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(4, 0)) == 16000);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(5, 0)) == 32000);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(6, 0)) == 50000);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(7, 0)) == 50000);
-        assertTrue(exponentialWait.computeSleepTime(failedAttempt(8, 0)) == 50000);
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8})
+    void testExponentialWithMultiplierAndMaximumWait(int attemptNumber) {
+        var multiplier = 1000;
+        var maximumTime = 50000;
+        var exponentialWait = WaitStrategies.exponentialWait(multiplier, maximumTime, TimeUnit.MILLISECONDS);
+
+        var unadjustedWait = multiplier * (long) Math.pow(2, attemptNumber);
+        var expectedWait = Math.min(unadjustedWait, maximumTime);
+
+        assertThat(exponentialWait.computeSleepTime(failedAttempt(attemptNumber, 0)))
+                .isEqualTo(expectedWait);
     }
 
-    @Test
-    void testFibonacci() {
-        WaitStrategy fibonacciWait = WaitStrategies.fibonacciWait();
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(1, 0L)) == 1L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(2, 0L)) == 1L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(3, 0L)) == 2L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(4, 0L)) == 3L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(5, 0L)) == 5L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(6, 0L)) == 8L);
+    @ParameterizedTest
+    @CsvSource({
+            "1, 1",
+            "2, 1",
+            "3, 2",
+            "4, 3",
+            "5, 5",
+            "6, 8"
+    })
+    void testFibonacci(int attemptNumber, long expectedSleep) {
+        var fibonacciWait = WaitStrategies.fibonacciWait();
+
+        assertThat(fibonacciWait.computeSleepTime(failedAttempt(attemptNumber, 0L)))
+                .isEqualTo(expectedSleep);
     }
 
-    @Test
-    void testFibonacciWithMaximumWait() {
-        WaitStrategy fibonacciWait = WaitStrategies.fibonacciWait(10L, TimeUnit.MILLISECONDS);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(1, 0L)) == 1L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(2, 0L)) == 1L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(3, 0L)) == 2L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(4, 0L)) == 3L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(5, 0L)) == 5L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(6, 0L)) == 8L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(7, 0L)) == 10L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(8, 0L)) == 10L);
+    @ParameterizedTest
+    @CsvSource({
+            "1, 1",
+            "2, 1",
+            "3, 2",
+            "4, 3",
+            "5, 5",
+            "6, 8",
+            "7, 10",
+            "8, 10",
+    })
+    void testFibonacciWithMaximumWait(int attemptNumber, long expectedSleep) {
+        var fibonacciWait = WaitStrategies.fibonacciWait(10L, TimeUnit.MILLISECONDS);
+
+        assertThat(fibonacciWait.computeSleepTime(failedAttempt(attemptNumber, 0L)))
+                .isEqualTo(expectedSleep);
     }
 
-    @Test
-    void testFibonacciWithMultiplierAndMaximumWait() {
-        WaitStrategy fibonacciWait = WaitStrategies.fibonacciWait(1000L, 50000L, TimeUnit.MILLISECONDS);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(1, 0L)) == 1000L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(2, 0L)) == 1000L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(3, 0L)) == 2000L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(4, 0L)) == 3000L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(5, 0L)) == 5000L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(6, 0L)) == 8000L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(7, 0L)) == 13000L);
-        assertTrue(fibonacciWait.computeSleepTime(failedAttempt(10, 0L)) == 50000L);
+    @ParameterizedTest
+    @CsvSource({
+            "1, 1000",
+            "2, 1000",
+            "3, 2000",
+            "4, 3000",
+            "5, 5000",
+            "6, 8000",
+            "7, 13000",
+            "8, 21000",
+            "9, 34000",
+            "10, 50000",
+            "11, 50000",
+            "12, 50000",
+    })
+    void testFibonacciWithMultiplierAndMaximumWait(int attemptNumber, long expectedSleep) {
+        var fibonacciWait = WaitStrategies.fibonacciWait(1000L, 50000L, TimeUnit.MILLISECONDS);
+
+        assertThat(fibonacciWait.computeSleepTime(failedAttempt(attemptNumber, 0L)))
+                .isEqualTo(expectedSleep);
     }
 
     @Test
     void testExceptionWait() {
-        WaitStrategy exceptionWait = WaitStrategies.exceptionWait(
-                RuntimeException.class, zeroSleepFunction());
-        assertEquals(0L, exceptionWait.computeSleepTime(failedAttempt(42, 7227)));
+        var failedAttempt = failedAttempt(42, 7227);
+        var exceptionWait = WaitStrategies.exceptionWait(RuntimeException.class, zeroSleepFunction());
+        assertThat(exceptionWait.computeSleepTime(failedAttempt)).isZero();
 
-        WaitStrategy oneMinuteWait = WaitStrategies.exceptionWait(RuntimeException.class, oneMinuteSleepFunction());
-        assertEquals(3600 * 1000L, oneMinuteWait.computeSleepTime(failedAttempt(42, 7227)));
+        var oneMinuteWait = WaitStrategies.exceptionWait(RuntimeException.class, oneMinuteSleepFunction());
+        assertThat(oneMinuteWait.computeSleepTime(failedAttempt)).isEqualTo(3600 * 1000L);
 
-        WaitStrategy noMatchRetryAfterWait = WaitStrategies.exceptionWait(RetryAfterException.class, customSleepFunction());
-        assertEquals(0L, noMatchRetryAfterWait.computeSleepTime(failedAttempt(42, 7227)));
+        var noMatchRetryAfterWait = WaitStrategies.exceptionWait(RetryAfterException.class, customSleepFunction());
+        assertThat(noMatchRetryAfterWait.computeSleepTime(failedAttempt)).isZero();
 
-        WaitStrategy retryAfterWait = WaitStrategies.exceptionWait(RetryAfterException.class, customSleepFunction());
-        Attempt<Boolean> failedAttempt = new Attempt<>(
-                new RetryAfterException(), 42, 7227L);
-        assertEquals(29L, retryAfterWait.computeSleepTime(failedAttempt));
+        var retryAfterWait = WaitStrategies.exceptionWait(RetryAfterException.class, customSleepFunction());
+        var failedRetryAfterAttempt = new Attempt<Boolean>(new RetryAfterException(), 42, 7227L);
+        assertThat(retryAfterWait.computeSleepTime(failedRetryAfterAttempt)).isEqualTo(RetryAfterException.SLEEP_TIME);
     }
 
     private Attempt<Boolean> failedAttempt(int attemptNumber, long delaySinceFirstAttempt) {
@@ -190,8 +209,10 @@ class WaitStrategiesTest {
 
     public static class RetryAfterException extends RuntimeException {
 
+        static final long SLEEP_TIME = 29L;
+
         long getRetryAfter() {
-            return 29L;
+            return SLEEP_TIME;
         }
     }
 }


### PR DESCRIPTION
Other changes:
* Split a few tests apart that were really separate tests
* Replaced a few try/catch/fail in tests with AssertJ constructs
  like assertThatThrownBy and catchThrowable combined with KiwiAssertJ
  from kiwi-test (which I added as a test scope dependency
* Converted repetitive code in tests to use @ParameterizedTest instead
  so that the test code is the same, and the @XxxSource for the test
  describes the test data and expected results, which is the only real
  difference
* RetryerTest was somehow still formatted with 2-space indent, so I
  fixed that too

Closes #6