### PR TITLE
Remove deprecated StopStrategies#stopAfterDelay(long millis)

### DIFF
--- a/src/main/java/com/github/rholder/retry/StopStrategies.java
+++ b/src/main/java/com/github/rholder/retry/StopStrategies.java
@@ -63,25 +63,9 @@ public final class StopStrategies {
      * given delay amount. If it has exceeded this delay, then using this
      * strategy causes the retrying to stop.
      *
-     * @param delayInMillis the delay, in milliseconds, starting from first attempt
-     * @return a stop strategy which stops after {@code delayInMillis} time in milliseconds
-     * @deprecated Use {@link #stopAfterDelay(long, TimeUnit)} instead.
-     */
-    @Deprecated
-    public static StopStrategy stopAfterDelay(long delayInMillis) {
-        return stopAfterDelay(delayInMillis, TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Returns a stop strategy which stops after a given delay. If an
-     * unsuccessful attempt is made, this {@link StopStrategy} will check if the
-     * amount of time that's passed from the first attempt has exceeded the
-     * given delay amount. If it has exceeded this delay, then using this
-     * strategy causes the retrying to stop.
-     *
      * @param duration the delay, starting from first attempt
      * @param timeUnit the unit of the duration
-     * @return a stop strategy which stops after {@code delayInMillis} time in milliseconds
+     * @return a stop strategy which stops after {@code duration} time in the given {@code timeUnit}
      */
     public static StopStrategy stopAfterDelay(long duration, @Nonnull TimeUnit timeUnit) {
         Preconditions.checkNotNull(timeUnit, "The time unit may not be null");

--- a/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
+++ b/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
@@ -54,19 +54,6 @@ class StopStrategiesTest {
             "1000, true",
             "1001, true"
     })
-    void testStopAfterDelayWithMilliseconds(long delaySinceFirstAttempt, boolean expectedShouldStop) {
-        //noinspection deprecation
-        var stopStrategy = StopStrategies.stopAfterDelay(1000);
-        assertThat(stopStrategy.shouldStop(failedAttempt(2, delaySinceFirstAttempt)))
-                .isEqualTo(expectedShouldStop);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            "999, false",
-            "1000, true",
-            "1001, true"
-    })
     void testStopAfterDelayWithTimeUnit(long delaySinceFirstAttempt, boolean expectedShouldStop) {
         var stopStrategy = StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS);
         assertThat(stopStrategy.shouldStop(failedAttempt(2, delaySinceFirstAttempt)))


### PR DESCRIPTION
This method was deprecated way back in 2015. There is no reason
whatsoever for us to continue including a deprecated method in a library
that we are now going to maintain.

Closes #12