### PR TITLE
Refactor duplicate RetryException code in tests

### DIFF
--- a/src/test/java/org/kiwiproject/retry/RetryExceptionAssert.java
+++ b/src/test/java/org/kiwiproject/retry/RetryExceptionAssert.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020-2021 Kiwi Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiwiproject.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.kiwiproject.test.assertj.KiwiAssertJ.assertIsExactType;
+
+import org.assertj.core.api.ThrowableAssert;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+class RetryExceptionAssert {
+
+    private final RetryException retryException;
+
+    RetryExceptionAssert(RetryException retryException) {
+        this.retryException = retryException;
+    }
+
+    static RetryExceptionAssert assertThatRetryExceptionThrownBy(ThrowableAssert.ThrowingCallable throwingCallable) {
+        var thrown = catchThrowable(throwingCallable);
+        var retryException = assertIsExactType(thrown, RetryException.class);
+        return assertThatRetryException(retryException);
+    }
+
+    static RetryExceptionAssert assertThatRetryException(RetryException retryException) {
+        return new RetryExceptionAssert(retryException);
+    }
+
+    RetryExceptionAssert hasNoCause() {
+        assertThat(retryException).hasNoCause();
+        return this;
+    }
+
+    RetryExceptionAssert hasCauseExactlyInstanceOf(Class<? extends Throwable> type) {
+        assertThat(retryException).hasCauseExactlyInstanceOf(type);
+        return this;
+    }
+
+    RetryExceptionAssert hasNumberOfFailedAttempts(int expected) {
+        assertThat(retryException.getNumberOfFailedAttempts()).isEqualTo(expected);
+        return this;
+    }
+
+    RetryExceptionAssert hasResultOnLastAttempt() {
+        assertThat(retryException.getLastFailedAttempt().hasResult()).isTrue();
+        assertThat(retryException.getLastFailedAttempt().hasException()).isFalse();
+        return this;
+    }
+
+    @SuppressWarnings({"SameParameterValue", "UnusedReturnValue"})
+    <T> RetryExceptionAssert hasResultOnLastAttempt(T expected) {
+        assertThat(retryException.getLastFailedAttempt().hasResult()).isTrue();
+        assertThat(retryException.getLastFailedAttempt().getResult()).isEqualTo(expected);
+        assertThat(retryException.getLastFailedAttempt().hasException()).isFalse();
+        return this;
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    RetryExceptionAssert hasExceptionOnLastAttempt() {
+        assertThat(retryException.getLastFailedAttempt().hasResult()).isFalse();
+        assertThat(retryException.getLastFailedAttempt().hasException()).isTrue();
+        return this;
+    }
+
+    RetryException getRetryException() {
+        return retryException;
+    }
+
+}

--- a/src/test/java/org/kiwiproject/retry/RetryerAssert.java
+++ b/src/test/java/org/kiwiproject/retry/RetryerAssert.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020-2021 Kiwi Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiwiproject.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.fail;
+import static org.kiwiproject.test.assertj.KiwiAssertJ.assertIsExactType;
+
+import java.util.concurrent.Callable;
+
+class RetryerAssert {
+
+    private final Retryer retryer;
+    private Object result;
+
+    private RetryerAssert(Retryer retryer) {
+        this.retryer = retryer;
+    }
+
+    static RetryerAssert assertThatRetryer(Retryer retryer) {
+        return new RetryerAssert(retryer);
+    }
+
+    <T> RetryExceptionAssert throwsRetryExceptionCalling(Callable<T> callable) {
+        var thrown = catchThrowable(() -> retryer.call(callable));
+        var retryException = assertIsExactType(thrown, RetryException.class);
+        return new RetryExceptionAssert(retryException);
+    }
+
+    <T> RetryerAssert completesSuccessfullyCalling(Callable<T> callable) {
+        try {
+            result = retryer.call(callable);
+        } catch (RetryException e) {
+            fail("Received unexpected RetryException");
+        } catch (InterruptedException e) {
+            fail("Received unexpected InterruptedException");
+        }
+        return this;
+    }
+
+    @SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
+    <T> RetryerAssert hasResult(T expected) {
+        assertThat(result).isEqualTo(expected);
+        return this;
+    }
+}

--- a/src/test/java/org/kiwiproject/retry/RetryerTest.java
+++ b/src/test/java/org/kiwiproject/retry/RetryerTest.java
@@ -19,8 +19,8 @@ package org.kiwiproject.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.kiwiproject.test.assertj.KiwiAssertJ.assertIsExactType;
+import static org.kiwiproject.retry.RetryExceptionAssert.assertThatRetryExceptionThrownBy;
+import static org.kiwiproject.retry.RetryerAssert.assertThatRetryer;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,12 +40,11 @@ class RetryerTest {
         var retryer = RetryerBuilder.newBuilder().build();
         var thrower = new Thrower(throwableClass, 5);
 
-        var thrown = catchThrowable(() -> retryer.call(thrower));
-        var retryException = assertIsExactType(thrown, RetryException.class);
-        assertThat(retryException).hasCauseExactlyInstanceOf(throwableClass);
-        assertThat(retryException.getNumberOfFailedAttempts()).isOne();
-        assertThat(retryException.getLastFailedAttempt().hasResult()).isFalse();
-        assertThat(retryException.getLastFailedAttempt().hasException()).isTrue();
+        assertThatRetryer(retryer)
+                .throwsRetryExceptionCalling(thrower)
+                .hasNumberOfFailedAttempts(1)
+                .hasExceptionOnLastAttempt();
+
         assertThat(thrower.invocations).isOne();
     }
 
@@ -55,12 +54,11 @@ class RetryerTest {
         var retryer = RetryerBuilder.newBuilder().build();
         var thrower = new Thrower(throwableClass, 5);
 
-        var thrown = catchThrowable(() -> retryer.run(thrower));
-        var retryException = assertIsExactType(thrown, RetryException.class);
-        assertThat(retryException).hasCauseExactlyInstanceOf(throwableClass);
-        assertThat(retryException.getNumberOfFailedAttempts()).isOne();
-        assertThat(retryException.getLastFailedAttempt().hasResult()).isFalse();
-        assertThat(retryException.getLastFailedAttempt().hasException()).isTrue();
+        assertThatRetryExceptionThrownBy(() -> retryer.run(thrower))
+                .hasCauseExactlyInstanceOf(throwableClass)
+                .hasNumberOfFailedAttempts(1)
+                .hasExceptionOnLastAttempt();
+
         assertThat(thrower.invocations).isOne();
     }
 
@@ -121,12 +119,12 @@ class RetryerTest {
                 .build();
         var thrower = new Thrower(throwableClass, 5);
 
-        var thrown = catchThrowable(() -> retryer.call(thrower));
-        var retryException = assertIsExactType(thrown, RetryException.class);
-        assertThat(retryException).hasCauseExactlyInstanceOf(throwableClass);
-        assertThat(retryException.getNumberOfFailedAttempts()).isEqualTo(3);
-        assertThat(retryException.getLastFailedAttempt().hasResult()).isFalse();
-        assertThat(retryException.getLastFailedAttempt().hasException()).isTrue();
+        assertThatRetryer(retryer)
+                .throwsRetryExceptionCalling(thrower)
+                .hasCauseExactlyInstanceOf(throwableClass)
+                .hasNumberOfFailedAttempts(3)
+                .hasExceptionOnLastAttempt();
+
         assertThat(thrower.invocations).isEqualTo(3);
     }
 
@@ -139,12 +137,11 @@ class RetryerTest {
                 .build();
         var thrower = new Thrower(throwableClass, 5);
 
-        var thrown = catchThrowable(() -> retryer.run(thrower));
-        var retryException = assertIsExactType(thrown, RetryException.class);
-        assertThat(retryException).hasCauseExactlyInstanceOf(throwableClass);
-        assertThat(retryException.getNumberOfFailedAttempts()).isEqualTo(3);
-        assertThat(retryException.getLastFailedAttempt().hasResult()).isFalse();
-        assertThat(retryException.getLastFailedAttempt().hasException()).isTrue();
+        assertThatRetryExceptionThrownBy(() -> retryer.run(thrower))
+                .hasCauseExactlyInstanceOf(throwableClass)
+                .hasNumberOfFailedAttempts(3)
+                .hasExceptionOnLastAttempt();
+
         assertThat(thrower.invocations).isEqualTo(3);
     }
 


### PR DESCRIPTION
* Introduce RetryerAssert and RetryExceptionAssert test helpers that
  are written in a fluent style (like AssertJ)
* Replace duplicate assertion code in tests using RetryerAssert and
  RetryExceptionAssert

Closes #24