### PR TITLE
Replace Guava collection factory methods with native JDK APIs

### DIFF
--- a/src/main/java/org/kiwiproject/retry/RetryerBuilder.java
+++ b/src/main/java/org/kiwiproject/retry/RetryerBuilder.java
@@ -19,7 +19,6 @@
 package org.kiwiproject.retry;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -34,7 +33,7 @@ public class RetryerBuilder {
     private StopStrategy stopStrategy;
     private WaitStrategy waitStrategy;
     private BlockStrategy blockStrategy;
-    private final List<Predicate<Attempt<?>>> retryPredicates = Lists.newArrayList();
+    private final List<Predicate<Attempt<?>>> retryPredicates = new ArrayList<>();
     private final List<RetryListener> listeners = new ArrayList<>();
 
     private RetryerBuilder() {

--- a/src/main/java/org/kiwiproject/retry/WaitStrategies.java
+++ b/src/main/java/org/kiwiproject/retry/WaitStrategies.java
@@ -19,10 +19,11 @@
 package org.kiwiproject.retry;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -226,7 +227,7 @@ public final class WaitStrategies {
      */
     public static WaitStrategy join(WaitStrategy... waitStrategies) {
         Preconditions.checkState(waitStrategies.length > 0, "Must have at least one wait strategy");
-        List<WaitStrategy> waitStrategyList = Lists.newArrayList(waitStrategies);
+        List<WaitStrategy> waitStrategyList = new ArrayList<>(Arrays.asList(waitStrategies));
         Preconditions.checkState(!waitStrategyList.contains(null), "Cannot have a null wait strategy");
         return new CompositeWaitStrategy(waitStrategyList);
     }

--- a/src/test/java/org/kiwiproject/retry/AttemptTimeLimitersTest.java
+++ b/src/test/java/org/kiwiproject/retry/AttemptTimeLimitersTest.java
@@ -18,10 +18,10 @@ package org.kiwiproject.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +30,7 @@ class AttemptTimeLimitersTest {
 
     @Test
     void testFixedTimeLimitWithNoExecutorReusesThreads() throws Exception {
-        Set<Long> threadsUsed = Collections.synchronizedSet(Sets.newHashSet());
+        Set<Long> threadsUsed = Collections.synchronizedSet(new HashSet<>());
         Callable<Void> callable = () -> {
             threadsUsed.add(Thread.currentThread().getId());
             return null;


### PR DESCRIPTION
* Replace Lists.newArrayList() with new ArrayList<>() in RetryerBuilder
* Replace Sets.newHashSet() w/new HashSet<>() in AttemptTimeLimitersTest
* Replace Lists.newArrayList(waitStrategies) to the more verbose
  new ArrayList<>(Arrays.asList(waitStrategies)) because of the null
  check below. For now just wanted to keep existing behavior as-is so
  this was one way using only native JDK API.

Closes #42