### PR TITLE
Retryer should catch Exception (not Throwable)

### DIFF
--- a/src/main/java/org/kiwiproject/retry/Attempt.java
+++ b/src/main/java/org/kiwiproject/retry/Attempt.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 /**
  * An attempt of a call, which resulted either in a result returned by the call,
- * or in a Throwable thrown by the call.
+ * or in an Exception thrown by the call.
  *
  * @param <T> The type returned by the wrapped callable.
  */
@@ -31,7 +31,7 @@ public class Attempt<T> {
 
     private final T result;
 
-    private final Throwable throwable;
+    private final Exception exception;
 
     private final int attemptNumber;
 
@@ -39,14 +39,14 @@ public class Attempt<T> {
 
     Attempt(T result, int attemptNumber, long delaySinceFirstAttempt) {
         this.result = result;
-        this.throwable = null;
+        this.exception = null;
         this.attemptNumber = attemptNumber;
         this.delaySinceFirstAttempt = delaySinceFirstAttempt;
     }
 
-    Attempt(Throwable throwable, int attemptNumber, long delaySinceFirstAttempt) {
+    Attempt(Exception exception, int attemptNumber, long delaySinceFirstAttempt) {
         this.result = null;
-        this.throwable = throwable;
+        this.exception = exception;
         this.attemptNumber = attemptNumber;
         this.delaySinceFirstAttempt = delaySinceFirstAttempt;
     }
@@ -60,7 +60,7 @@ public class Attempt<T> {
     public boolean hasResult() {
         // Check the exception field, because the Callable may have succeeded and returned null.
         // In that case both exception and result will be null.
-        return throwable == null;
+        return exception == null;
     }
 
     /**
@@ -70,7 +70,7 @@ public class Attempt<T> {
      * if it returned a result
      */
     public boolean hasException() {
-        return throwable != null;
+        return exception != null;
     }
 
     /**
@@ -92,9 +92,9 @@ public class Attempt<T> {
      * @throws IllegalStateException if the call didn't throw an exception,
      *                               as indicated by {@link #hasException()}
      */
-    public Throwable getException() {
+    public Exception getException() {
         checkState(hasException(), "The attempt resulted in a result, not in an exception");
-        return throwable;
+        return exception;
     }
 
     /**

--- a/src/main/java/org/kiwiproject/retry/Retryer.java
+++ b/src/main/java/org/kiwiproject/retry/Retryer.java
@@ -99,8 +99,8 @@ public final class Retryer {
                 attempt = new Attempt<>(result, attemptNumber, computeMillisSince(startTimeNanos));
             } catch (InterruptedException e) {
                 throw e;
-            } catch (Throwable t) {
-                attempt = new Attempt<>(t, attemptNumber, computeMillisSince(startTimeNanos));
+            } catch (Exception e) {
+                attempt = new Attempt<>(e, attemptNumber, computeMillisSince(startTimeNanos));
             }
 
             for (RetryListener listener : listeners) {

--- a/src/main/java/org/kiwiproject/retry/RetryerBuilder.java
+++ b/src/main/java/org/kiwiproject/retry/RetryerBuilder.java
@@ -143,7 +143,7 @@ public class RetryerBuilder {
      * @param exceptionClass the type of the exception which should cause the retryer to retry
      * @return <code>this</code>
      */
-    public RetryerBuilder retryIfExceptionOfType(@Nonnull Class<? extends Throwable> exceptionClass) {
+    public RetryerBuilder retryIfExceptionOfType(@Nonnull Class<? extends Exception> exceptionClass) {
         Preconditions.checkNotNull(exceptionClass, "exceptionClass may not be null");
         retryPredicates.add(new ExceptionClassPredicate(exceptionClass));
         return this;
@@ -156,7 +156,7 @@ public class RetryerBuilder {
      * @param exceptionPredicate the predicate which causes a retry if satisfied
      * @return <code>this</code>
      */
-    public RetryerBuilder retryIfException(@Nonnull Predicate<Throwable> exceptionPredicate) {
+    public RetryerBuilder retryIfException(@Nonnull Predicate<Exception> exceptionPredicate) {
         Preconditions.checkNotNull(exceptionPredicate, "exceptionPredicate may not be null");
         retryPredicates.add(new ExceptionPredicate(exceptionPredicate));
         return this;
@@ -198,9 +198,9 @@ public class RetryerBuilder {
 
     private static final class ExceptionClassPredicate implements Predicate<Attempt<?>> {
 
-        private final Class<? extends Throwable> exceptionClass;
+        private final Class<? extends Exception> exceptionClass;
 
-        ExceptionClassPredicate(Class<? extends Throwable> exceptionClass) {
+        ExceptionClassPredicate(Class<? extends Exception> exceptionClass) {
             this.exceptionClass = exceptionClass;
         }
 
@@ -236,9 +236,9 @@ public class RetryerBuilder {
 
     private static final class ExceptionPredicate implements Predicate<Attempt<?>> {
 
-        private final Predicate<Throwable> delegate;
+        private final Predicate<Exception> delegate;
 
-        ExceptionPredicate(Predicate<Throwable> delegate) {
+        ExceptionPredicate(Predicate<Exception> delegate) {
             this.delegate = delegate;
         }
 


### PR DESCRIPTION
* Rename throwable field to exception in Attempt and change it to have
  type Exception instead of Throwable
* Change Retryer#call to catch Exception instead of Throwable
* Change RetryerBuilder exception predicate methods to accept Exception
  instead of Throwable; change internal ExceptionClassPredicate to use
  Exception as the wildcard upper bound
* Update RetryerTest to use Exception as the upper wildcard bound in
  tests that were using Throwable
* Add tests for both call and run in RetryerTest to verify Error and
  its subclasses are not caught

Closes #54