### PR TITLE
Add test for AttemptTimeLimiters#fixedTimeLimit with Executor

### DIFF
--- a/src/main/java/org/kiwiproject/retry/AttemptTimeLimiters.java
+++ b/src/main/java/org/kiwiproject/retry/AttemptTimeLimiters.java
@@ -82,6 +82,8 @@ public class AttemptTimeLimiters {
         }
     }
 
+    // Suppress API warnings about TimeLimiter in Guava which has been there since version 1.0
+    @SuppressWarnings("UnstableApiUsage")
     @Immutable
     private static final class FixedAttemptTimeLimit implements AttemptTimeLimiter {
 

--- a/src/test/java/org/kiwiproject/retry/AttemptTimeLimitersTest.java
+++ b/src/test/java/org/kiwiproject/retry/AttemptTimeLimitersTest.java
@@ -24,28 +24,70 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 class AttemptTimeLimitersTest {
 
     @Test
     void testFixedTimeLimitWithNoExecutorReusesThreads() throws Exception {
-        Set<Long> threadsUsed = Collections.synchronizedSet(new HashSet<>());
-        Callable<Void> callable = () -> {
-            threadsUsed.add(Thread.currentThread().getId());
-            return null;
-        };
+        Set<Long> threadsUsed = synchronizedSet();
+        Callable<Void> callable = newTestCallable(threadsUsed);
 
-        int iterations = 20;
-        for (int i = 0; i < iterations; i++) {
-            AttemptTimeLimiter timeLimiter =
-                    AttemptTimeLimiters.fixedTimeLimit(1, TimeUnit.SECONDS);
+        var iterations = 20;
+        callMultipleTimesWithNewTimeLimiter(callable, 20, AttemptTimeLimitersTest::newFixedTimeLimiter);
+
+        assertThat(threadsUsed)
+                .describedAs("Should have used less than %d threads", iterations)
+                .hasSizeLessThan(iterations);
+    }
+
+    @Test
+    void testFixedTimeLimitWithProvidedExecutor() throws Exception {
+        Set<Long> threadsUsed = synchronizedSet();
+        Callable<Void> callable = newTestCallable(threadsUsed);
+
+        var numThreads = 3;
+        var executor = Executors.newFixedThreadPool(numThreads);
+
+        var iterations = 25;
+        callMultipleTimesWithNewTimeLimiter(callable, iterations, () -> newFixedTimeLimiter(executor));
+
+        assertThat(threadsUsed)
+                .describedAs("Expected to have used %d threads", numThreads)
+                .hasSize(numThreads);
+    }
+
+    private static void callMultipleTimesWithNewTimeLimiter(Callable<Void> callable,
+                                                            int numIterations,
+                                                            Supplier<AttemptTimeLimiter> supplier) throws Exception {
+
+        for (int i = 0; i < numIterations; i++) {
+            var timeLimiter = supplier.get();
             timeLimiter.call(callable);
         }
+    }
 
-        assertThat(threadsUsed.size())
-                .describedAs("Should have used less than %d threads", iterations)
-                .isLessThan(iterations);
+    private static AttemptTimeLimiter newFixedTimeLimiter() {
+        return AttemptTimeLimiters.fixedTimeLimit(1, TimeUnit.SECONDS);
+    }
+
+    private static AttemptTimeLimiter newFixedTimeLimiter(ExecutorService executor) {
+        return AttemptTimeLimiters.fixedTimeLimit(1, TimeUnit.SECONDS, executor);
+    }
+
+    private Set<Long> synchronizedSet() {
+        return Collections.synchronizedSet(new HashSet<>());
+    }
+
+    private Callable<Void> newTestCallable(Set<Long> threadsUsed) {
+        return () -> {
+            var id = Thread.currentThread().getId();
+            threadsUsed.add(id);
+            return null;
+        };
     }
 
 }


### PR DESCRIPTION
* Suppress unstable API warnings in AttemptTimeLimiters about Guava's
  TimeLimiter; it has been there since version 1.0 so it is probably
  not going away anytime soon.
* Add test for the AttemptTimeLimiters#fixedTimeLimit that takes an
  ExecutorService as its last argument
* Refactor AttemptTimeLimitersTest to re-use code between the original
  test and the new one