### PR TITLE
Replace Attempt constructors with factory methods in Attempt

### DIFF
--- a/src/main/java/org/kiwiproject/retry/Attempt.java
+++ b/src/main/java/org/kiwiproject/retry/Attempt.java
@@ -37,18 +37,45 @@ public class Attempt<T> {
 
     private final long delaySinceFirstAttempt;
 
-    Attempt(T result, int attemptNumber, long delaySinceFirstAttempt) {
+    private Attempt(T result, int attemptNumber, long delaySinceFirstAttempt) {
+        this(result, null, attemptNumber, delaySinceFirstAttempt);
+    }
+
+    private Attempt(Exception exception, int attemptNumber, long delaySinceFirstAttempt) {
+        this(null, exception, attemptNumber, delaySinceFirstAttempt);
+    }
+
+    private Attempt(T result, Exception exception, int attemptNumber, long delaySinceFirstAttempt) {
         this.result = result;
-        this.exception = null;
+        this.exception = exception;
         this.attemptNumber = attemptNumber;
         this.delaySinceFirstAttempt = delaySinceFirstAttempt;
     }
 
-    Attempt(Exception exception, int attemptNumber, long delaySinceFirstAttempt) {
-        this.result = null;
-        this.exception = exception;
-        this.attemptNumber = attemptNumber;
-        this.delaySinceFirstAttempt = delaySinceFirstAttempt;
+    /**
+     * Create a new {@link Attempt} that has a result.
+     *
+     * @param result                 the result of the attempt
+     * @param attemptNumber          the number of this attempt
+     * @param delaySinceFirstAttempt the delay in milliseconds since the first attempt was made
+     * @param <T>                    the type of result
+     * @return a new Attempt instance
+     */
+    static <T> Attempt<T> newResultAttempt(T result, int attemptNumber, long delaySinceFirstAttempt) {
+        return new Attempt<>(result, attemptNumber, delaySinceFirstAttempt);
+    }
+
+    /**
+     * Create a new {@link Attempt} that failed with an exception.
+     *
+     * @param exception              the exception thrown by this attempt
+     * @param attemptNumber          the number of this attempt
+     * @param delaySinceFirstAttempt the delay in milliseconds since the first attempt was made
+     * @param <T>                    the type of result the attempt would have returned if it had not thrown an exception
+     * @return a new Attempt instance
+     */
+    static <T> Attempt<T> newExceptionAttempt(Exception exception, int attemptNumber, long delaySinceFirstAttempt) {
+        return new Attempt<>(exception, attemptNumber, delaySinceFirstAttempt);
     }
 
     /**

--- a/src/main/java/org/kiwiproject/retry/Retryer.java
+++ b/src/main/java/org/kiwiproject/retry/Retryer.java
@@ -18,6 +18,9 @@
 
 package org.kiwiproject.retry;
 
+import static org.kiwiproject.retry.Attempt.newExceptionAttempt;
+import static org.kiwiproject.retry.Attempt.newResultAttempt;
+
 import com.google.common.base.Preconditions;
 
 import javax.annotation.Nonnull;
@@ -96,11 +99,11 @@ public final class Retryer {
             Attempt<T> attempt;
             try {
                 T result = attemptTimeLimiter.call(callable);
-                attempt = new Attempt<>(result, attemptNumber, computeMillisSince(startTimeNanos));
+                attempt = newResultAttempt(result, attemptNumber, computeMillisSince(startTimeNanos));
             } catch (InterruptedException e) {
                 throw e;
             } catch (Exception e) {
-                attempt = new Attempt<>(e, attemptNumber, computeMillisSince(startTimeNanos));
+                attempt = newExceptionAttempt(e, attemptNumber, computeMillisSince(startTimeNanos));
             }
 
             for (RetryListener listener : listeners) {

--- a/src/test/java/org/kiwiproject/retry/StopStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/retry/StopStrategiesTest.java
@@ -61,6 +61,6 @@ class StopStrategiesTest {
     }
 
     private Attempt<Boolean> failedAttempt(int attemptNumber, long delaySinceFirstAttempt) {
-        return new Attempt<>(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
+        return Attempt.newExceptionAttempt(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
     }
 }

--- a/src/test/java/org/kiwiproject/retry/WaitStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/retry/WaitStrategiesTest.java
@@ -187,12 +187,12 @@ class WaitStrategiesTest {
         assertThat(noMatchRetryAfterWait.computeSleepTime(failedAttempt)).isZero();
 
         var retryAfterWait = WaitStrategies.exceptionWait(RetryAfterException.class, customSleepFunction());
-        var failedRetryAfterAttempt = new Attempt<Boolean>(new RetryAfterException(), 42, 7227L);
+        var failedRetryAfterAttempt = Attempt.<Boolean>newExceptionAttempt(new RetryAfterException(), 42, 7227L);
         assertThat(retryAfterWait.computeSleepTime(failedRetryAfterAttempt)).isEqualTo(RetryAfterException.SLEEP_TIME);
     }
 
     private Attempt<Boolean> failedAttempt(int attemptNumber, long delaySinceFirstAttempt) {
-        return new Attempt<>(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
+        return Attempt.newExceptionAttempt(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
     }
 
     private Function<RuntimeException, Long> zeroSleepFunction() {


### PR DESCRIPTION
* Add newResultAttempt and newExceptionAttempt factory methods
* Add new private all-args constructor
* Make existing constructors private and make them call all-args ctor
* Update StopStrategiesTest and WaitStrategiesTest to use new factories

Closes #62