### PR TITLE
Catch exceptions thrown by a RetryListener

### DIFF
--- a/src/main/java/org/kiwiproject/retry/RetryListener.java
+++ b/src/main/java/org/kiwiproject/retry/RetryListener.java
@@ -29,6 +29,8 @@ public interface RetryListener {
      * retry predicate and stop strategies are applied.
      *
      * @param attempt the current {@link Attempt}
+     * @apiNote No exceptions should be thrown from this method. But, if an exception is thrown by an
+     * implementation, it will be silently ignored so that it does not halt processing of a {@link Retryer}.
      */
     void onRetry(Attempt<?> attempt);
 }


### PR DESCRIPTION
* Add safeInvokeListener in Retryer which catches and silently ignores
  Exceptions
* Change the for loop that calls each RetryListener in Retryer to a
  forEach that invokes safeInvokeListener
* Add an API Note in RetryListener mentioning that implementations
  should not thrown any exceptions, and that any thrown exceptions will
  be caught and ignored
* Extract method that performs the call of the Callable and the
  exception handling into a private 'call' method. This cleans up the
  code a little bit in the public 'call' method.

Misc:

* Static import Preconditions#checkNotNull in Retryer so the constructor
  is a bit less "noisy"
* Remove obsolete ConstantConditions warning suppression comment in
  RetryerBuilderTest

Closes #63