### PR TITLE
Sonar: Make Attempt transient in RetryException

### DIFF
--- a/src/main/java/org/kiwiproject/retry/RetryException.java
+++ b/src/main/java/org/kiwiproject/retry/RetryException.java
@@ -18,6 +18,9 @@
 
 package org.kiwiproject.retry;
 
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.nonNull;
+
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
@@ -29,7 +32,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class RetryException extends Exception {
 
-    private final Attempt<?> lastFailedAttempt;
+    private final transient Attempt<?> lastFailedAttempt;
 
     /**
      * If the last {@link Attempt} had an Exception, ensure it is available in
@@ -38,9 +41,11 @@ public final class RetryException extends Exception {
      * @param attempt what happened the last time we failed
      */
     RetryException(@Nonnull Attempt<?> attempt) {
-        this("Retrying failed to complete successfully after " +
-                        attempt.getAttemptNumber() + " attempts.",
-                attempt);
+        this(errorMessageFor(attempt), attempt);
+    }
+
+    private static String errorMessageFor(Attempt<?> attempt) {
+        return "Retrying failed to complete successfully after " + attempt.getAttemptNumber() + " attempts.";
     }
 
     /**
@@ -61,6 +66,7 @@ public final class RetryException extends Exception {
      * @return the number of failed attempts
      */
     public int getNumberOfFailedAttempts() {
+        checkState(nonNull(lastFailedAttempt), "lastFailedAttempt is null; cannot get attempt number");
         return lastFailedAttempt.getAttemptNumber();
     }
 


### PR DESCRIPTION
Mark the Attempt field in RetryException as transient to make Sonar
happy.

While technically Sonar rule java:S1948 (Fields in a "Serializable"
class should either be transient or serializable) is true, it seems
highly unlikely that an exception would be serialized to disk during
any processing. The rule gives the example of a JEE application server
flushing objects to disk under heavy load, but again it seems very
unlikely that an exception would ever be serialized, since exceptions
generally need to be handled (or simply propagated) "right now".

If I am wrong about this behavior and a RetryException ever gets
serialized to disk, and then gets de-serialized somewhere else, and then
someone attempts (ha, a pun) to call getNumberOfFailedAttempts(), they
could get a NPE. While not lovely, I'm not going to (at present unless
someone shows me a real-life example of this happening) modify the
getNumberOfFailedAttempts() method to handle this case other than to
check that the lastFailedAttempt is non-null, and throw an
IllegalStateException if it actually is null. So they will receive
an IllegalStateException with an explanation instead of an NPE, which
ultimately I suppose is better.