### PR TITLE
Bump kiwi-parent and error_prone_annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>0.14.0</version>
+        <version>0.15.0</version>
     </parent>
 
     <artifactId>retrying-again</artifactId>
@@ -50,7 +50,7 @@
         <guava.version>30.1.1-jre</guava.version>
 
         <!-- Versions for optional dependencies -->
-        <error_prone_annotations.version>2.7.1</error_prone_annotations.version>
+        <error_prone_annotations.version>2.8.0</error_prone_annotations.version>
         <jsr305.version>3.0.2</jsr305.version>
 
         <!-- Sonar properties -->


### PR DESCRIPTION
* Bump kiwi-parent from 0.14.0 to 0.15.0
* Bump error_prone_annotations from 2.7.1 to 2.8.0