### PR TITLE
Bump print-delombok action from 0.6.0 to 0.7.0

### DIFF
--- a/.github/workflows/print-delomboked-sources.yml
+++ b/.github/workflows/print-delomboked-sources.yml
@@ -22,4 +22,4 @@ jobs:
         uses: sleberknight/delombok-action@v0.7.0
         
       - name: Print the Delomboked code
-        uses: sleberknight/print-delombok@3-handle-missing-delombok-directory
+        uses: sleberknight/print-delombok@v0.7.0


### PR DESCRIPTION
This handles the case when there are no Delomboked sources.