### PR TITLE
Add GitHub action to update copyright years in NOTICE

### DIFF
--- a/.github/workflows/update-license-copyright-years.yml
+++ b/.github/workflows/update-license-copyright-years.yml
@@ -1,0 +1,20 @@
+name: Update copyright year(s) in license file
+
+on:
+  schedule:
+    - cron: '5 3 1 1 *' # 03:05 AM on January 1
+  workflow_dispatch:
+    # no inputs needed here
+
+jobs:
+  update-license-year:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: FantasticFiasco/action-update-license-year@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: NOTICE
+          labels: documentation


### PR DESCRIPTION
Note that this probably won't work since there are multiple copyrights.

But at least it will remind us to go update the copyrights!

Closes #178 