### PR TITLE
Sonar cleanup: fix deprecated API usage

### DIFF
--- a/src/test/java/org/kiwiproject/retry/RetryExceptionAssert.java
+++ b/src/test/java/org/kiwiproject/retry/RetryExceptionAssert.java
@@ -15,7 +15,7 @@ class RetryExceptionAssert {
     }
 
     static RetryExceptionAssert assertThatRetryExceptionThrownBy(ThrowableAssert.ThrowingCallable throwingCallable) {
-        var retryException = catchThrowableOfType(throwingCallable, RetryException.class);
+        var retryException = catchThrowableOfType(RetryException.class, throwingCallable);
         return assertThatRetryException(retryException);
     }
 

--- a/src/test/java/org/kiwiproject/retry/RetryerAssert.java
+++ b/src/test/java/org/kiwiproject/retry/RetryerAssert.java
@@ -20,7 +20,7 @@ class RetryerAssert {
     }
 
     <T> RetryExceptionAssert throwsRetryExceptionCalling(Callable<T> callable) {
-        var retryException = catchThrowableOfType(() -> retryer.call(callable), RetryException.class);
+        var retryException = catchThrowableOfType(RetryException.class, () -> retryer.call(callable));
         return new RetryExceptionAssert(retryException);
     }
 


### PR DESCRIPTION
Change usages of deprecated catchThrowableOfType.
The replacement simply switches the argument order, for "reasons".